### PR TITLE
Add blog pagination and filter pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro"
+    "astro": "astro",
+    "new-post": "node ./scripts/new-post.js"
   },
   "dependencies": {
     "astro": "^5.8.0",

--- a/scripts/new-post.js
+++ b/scripts/new-post.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+const [title, slugArg] = process.argv.slice(2);
+if (!title) {
+  console.error('Usage: npm run new-post "Title" [slug]');
+  process.exit(1);
+}
+const slug = slugArg || title.toLowerCase().replace(/\s+/g, '-');
+const today = new Date().toISOString().split('T')[0];
+const filePath = path.join('src/content/blog', `${slug}.md`);
+
+const frontmatter = `---\ntitle: ${title}\npubDate: ${today}\n---\n\n`; // Add tags or category manually after creation
+
+fs.writeFileSync(filePath, frontmatter);
+console.log(`Created ${filePath}`);
+
+try {
+  execSync('npm run build', { stdio: 'inherit' });
+} catch (err) {
+  console.error('Build failed:', err);
+}

--- a/src/content/blog/hello-world.md
+++ b/src/content/blog/hello-world.md
@@ -1,6 +1,9 @@
 ---
 title: Hello World
 pubDate: 2023-10-26
+category: general
+tags:
+  - intro
 ---
 
 # Hello, world!

--- a/src/content/blog/my-second-post.md
+++ b/src/content/blog/my-second-post.md
@@ -1,6 +1,9 @@
 ---
 title: My Second Post
 pubDate: 2023-10-27
+category: updates
+tags:
+  - update
 ---
 
 # This is my second blog post!

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,0 +1,15 @@
+import { defineCollection, z } from 'astro:content';
+
+const blogCollection = defineCollection({
+  schema: z.object({
+    title: z.string(),
+    pubDate: z.coerce.date(),
+    description: z.string().optional(),
+    category: z.string().optional(),
+    tags: z.array(z.string()).optional(),
+  }),
+});
+
+export const collections = {
+  blog: blogCollection,
+};

--- a/src/pages/blog/category/[category].astro
+++ b/src/pages/blog/category/[category].astro
@@ -1,0 +1,32 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+import { getCollection, type CollectionEntry } from 'astro:content';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  const categories = Array.from(new Set(posts.map(p => p.data.category).filter(Boolean)));
+  return categories.map(category => ({
+    params: { category },
+  }));
+}
+
+const { category } = Astro.params;
+const posts = (await getCollection('blog'))
+  .filter((p) => p.data.category === category)
+  .sort((a,b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+---
+
+<Layout title={`Category: ${category}`}> 
+  <main>
+    <div class="container mx-auto py-8">
+      <h1 class="text-3xl font-bold mb-4">Category: {category}</h1>
+      <ul>
+        {posts.map((post) => (
+          <li class="mb-2">
+            <a href={`/blog/${post.slug}/`} class="text-blue-500 hover:underline">{post.data.title}</a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </main>
+</Layout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -2,9 +2,15 @@
 import Layout from '../../layouts/Layout.astro';
 import { getCollection, type CollectionEntry } from 'astro:content';
 
+const POSTS_PER_PAGE = 5;
+
 type BlogPost = CollectionEntry<'blog'>;
 
-const posts: BlogPost[] = await getCollection('blog');
+const allPosts: BlogPost[] = (await getCollection('blog')).sort(
+  (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
+);
+const posts = allPosts.slice(0, POSTS_PER_PAGE);
+const total = Math.ceil(allPosts.length / POSTS_PER_PAGE);
 ---
 
 <Layout title="Blog">
@@ -18,6 +24,11 @@ const posts: BlogPost[] = await getCollection('blog');
           </li>
         ))}
       </ul>
+      {total > 1 && (
+        <nav class="mt-4">
+          <a href="/blog/page/2/">Next &raquo;</a>
+        </nav>
+      )}
     </div>
   </main>
 </Layout>

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -1,0 +1,44 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+import { getCollection, type CollectionEntry } from 'astro:content';
+
+const POSTS_PER_PAGE = 5;
+
+export async function getStaticPaths() {
+  const allPosts = (await getCollection('blog')).sort((a,b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+  const total = Math.ceil(allPosts.length / POSTS_PER_PAGE);
+  return Array.from({ length: total }).map((_, i) => {
+    const start = i * POSTS_PER_PAGE;
+    const end = start + POSTS_PER_PAGE;
+    return {
+      params: { page: String(i + 1) },
+      props: { posts: allPosts.slice(start, end), page: i + 1, total },
+    };
+  });
+}
+
+const { posts, page, total } = Astro.props as {
+  posts: CollectionEntry<'blog'>[];
+  page: number;
+  total: number;
+};
+---
+
+<Layout title={`Blog - Page ${page}`}> 
+  <main>
+    <div class="container mx-auto py-8">
+      <h1 class="text-3xl font-bold mb-4">Blog</h1>
+      <ul>
+        {posts.map((post) => (
+          <li class="mb-2">
+            <a href={`/blog/${post.slug}/`} class="text-blue-500 hover:underline">{post.data.title}</a>
+          </li>
+        ))}
+      </ul>
+      <nav class="mt-4 flex gap-2">
+        {page > 1 && <a href={page - 1 === 1 ? '/blog/' : `/blog/page/${page - 1}/`}>&laquo; Prev</a>}
+        {page < total && <a href={`/blog/page/${page + 1}/`}>Next &raquo;</a>}
+      </nav>
+    </div>
+  </main>
+</Layout>

--- a/src/pages/blog/tag/[tag].astro
+++ b/src/pages/blog/tag/[tag].astro
@@ -1,0 +1,32 @@
+---
+import Layout from '../../../layouts/Layout.astro';
+import { getCollection, type CollectionEntry } from 'astro:content';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  const tags = Array.from(new Set(posts.flatMap(p => p.data.tags || [])));
+  return tags.map(tag => ({
+    params: { tag },
+  }));
+}
+
+const { tag } = Astro.params;
+const posts = (await getCollection('blog'))
+  .filter((p) => (p.data.tags || []).includes(tag))
+  .sort((a,b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+---
+
+<Layout title={`Posts tagged ${tag}`}> 
+  <main>
+    <div class="container mx-auto py-8">
+      <h1 class="text-3xl font-bold mb-4">Tag: {tag}</h1>
+      <ul>
+        {posts.map((post) => (
+          <li class="mb-2">
+            <a href={`/blog/${post.slug}/`} class="text-blue-500 hover:underline">{post.data.title}</a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </main>
+</Layout>


### PR DESCRIPTION
## Summary
- enable optional tags & category via content config
- add script to create a new post and auto-build
- extend posts with tags and categories
- add pagination to blog index
- add dynamic pages for paginated listing, tag filtering, and category filtering

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ab50d170832a99057ba57ff759f3