### PR TITLE
Improve blog image shortcode handling

### DIFF
--- a/src/components/ImageShortcode.astro
+++ b/src/components/ImageShortcode.astro
@@ -1,26 +1,36 @@
 ---
 export interface Props {
   src: string;
-  alt: string;
+  alt?: string;
   width?: number;
   height?: number;
 }
 
-console.log('[ImageShortcode] props:', Astro.props);
+const { src, alt = '', width, height } = Astro.props;
 
-const { src, alt, width, height } = Astro.props;
+// Import all images from the assets folder eagerly so they can be looked up by
+// filename at runtime. This allows markdown shortcodes to reference any image
+// without updating this component each time.
+const imageMap = import.meta.glob('../../assets/images/**/*', {
+  eager: true,
+  import: 'default',
+});
 
-const imageMap: Record<string, any> = {
-  '/assets/images/logo.jpg': await import('../../assets/images/logo.jpg'),
-};
+function resolveImage(path: string) {
+  const normalized = path.replace(/^\/?/, '');
+  for (const [key, mod] of Object.entries(imageMap)) {
+    if (key.endsWith(normalized)) return mod as unknown as string;
+  }
+  return undefined;
+}
 
-const image = imageMap[src];
+const imageSrc = resolveImage(src);
 
 import { Image } from 'astro:assets';
 ---
 
-{image ? (
-  <Image src={image.default} alt={alt} width={width} height={height} />
+{imageSrc ? (
+  <Image src={imageSrc} alt={alt} width={width} height={height} />
 ) : (
   <div class="bg-yellow-500 text-black p-2">
     <p>⚠️ Image not found for <strong>{src}</strong></p>

--- a/src/pages/blog/page/[page].astro
+++ b/src/pages/blog/page/[page].astro
@@ -21,12 +21,9 @@ const { posts, page, total } = Astro.props as {
   page: number;
   total: number;
 };
-
 ---
 
-
-
-<Layout title={`Blog - Page ${page}`}> 
+<Layout title={`Blog - Page ${page}`}>
   <main>
     <div class="container mx-auto py-8">
       <h1 class="text-3xl font-bold mb-4">Blog</h1>
@@ -34,3 +31,13 @@ const { posts, page, total } = Astro.props as {
         {posts.map((post) => (
           <li class="mb-2">
             <a href={`/blog/${post.slug}/`} class="text-blue-500 hover:underline">{post.data.title}</a>
+          </li>
+        ))}
+      </ul>
+      <nav class="mt-4 flex gap-2">
+        {page > 1 && <a href={page - 1 === 1 ? '/blog/' : `/blog/page/${page - 1}/`}>&laquo; Prev</a>}
+        {page < total && <a href={`/blog/page/${page + 1}/`}>Next &raquo;</a>}
+      </nav>
+    </div>
+  </main>
+</Layout>


### PR DESCRIPTION
## Summary
- allow ImageShortcode to load any image from `src/assets/images`
- keep using Markdown-based blog posts with shortcode syntax
- fix syntax error in pagination page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845c9f142a4832ab41b7db931f2ecb5