### PR TITLE
Optimize scroll spy

### DIFF
--- a/src/scripts/scroll-spy.js
+++ b/src/scripts/scroll-spy.js
@@ -1,11 +1,20 @@
 const sections = document.querySelectorAll("section[id]");
 const navLinks = document.querySelectorAll(".nav-link");
 
+// Build a map of section IDs to their corresponding navigation links
+const navLinkMap = new Map();
+navLinks.forEach((link) => {
+  const sectionId = link.dataset.section;
+  if (sectionId) {
+    navLinkMap.set(sectionId, link);
+  }
+});
+
 const observer = new IntersectionObserver(
   (entries) => {
     entries.forEach((entry) => {
       const id = entry.target.id;
-      const navLink = document.querySelector(`.nav-link[data-section="${id}"]`);
+      const navLink = navLinkMap.get(id);
 
       if (entry.isIntersecting) {
         navLinks.forEach((link) => link.classList.remove("active"));


### PR DESCRIPTION
## Summary
- precompute a map of section id to nav link
- use this map inside the IntersectionObserver callback

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68486f255078832ab008e3dc29efd9d3