### PR TITLE
Cache theme root in spotlight

### DIFF
--- a/src/scripts/spotlight.js
+++ b/src/scripts/spotlight.js
@@ -1,4 +1,5 @@
 const spotlight = document.getElementById("spotlight");
+const themeRoot = document.documentElement;
 
 let targetX = 0;
 let targetY = 0;
@@ -20,7 +21,6 @@ function hexToRgb(hex) {
 }
 
 function updateAccentFromTheme() {
-  const themeRoot = document.querySelector("[data-theme]") || document.documentElement;
   const theme = themeRoot.getAttribute("data-theme") || "default";
 
   if (theme !== currentTheme) {
@@ -29,9 +29,6 @@ function updateAccentFromTheme() {
     currentAccent = accentRgb;
     currentTheme = theme;
 
-    console.log(`[theme-switch] Theme: ${theme}`);
-    console.log(`[theme-switch] --color-accent: ${accentHex}`);
-    console.log(`[theme-switch] Computed RGB: ${accentRgb}`);
   }
 }
 


### PR DESCRIPTION
## Summary
- cache the theme root element for the spotlight animation
- drop debug logging in spotlight script

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68486f61dacc832a9f3f2ba67dc97da5