### PR TITLE
Add remark plugin for image shortcode

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,9 +1,13 @@
 import { defineConfig } from 'astro/config';
 import tailwind from '@astrojs/tailwind';
+import remarkImageShortcode from './src/plugins/remark-image-shortcode.js';
 
 // https://astro.build/config
 export default defineConfig({
   integrations: [
     tailwind(),
   ],
+  markdown: {
+    remarkPlugins: [remarkImageShortcode],
+  },
 });

--- a/src/plugins/remark-image-shortcode.js
+++ b/src/plugins/remark-image-shortcode.js
@@ -1,0 +1,51 @@
+import { visit } from 'unist-util-visit';
+
+/**
+ * Remark plugin to transform custom Image shortcode into an `image` node.
+ * Matches patterns like:
+ *   {{< Image src="/path" alt="Alt" width="600" height="400" >}}
+ */
+export default function remarkImageShortcode() {
+  return function transformer(tree) {
+    visit(tree, 'text', (node, index, parent) => {
+      if (!parent || typeof node.value !== 'string') return;
+      const regex = /{{<\s*Image([^>]+)>}}/g;
+      const value = node.value;
+      let match;
+      let lastIndex = 0;
+      const newNodes = [];
+
+      while ((match = regex.exec(value))) {
+        if (match.index > lastIndex) {
+          newNodes.push({ type: 'text', value: value.slice(lastIndex, match.index) });
+        }
+
+        const attrsString = match[1];
+        const attrRegex = /(\w+)="([^"]*)"/g;
+        const props = {};
+        let attrMatch;
+        while ((attrMatch = attrRegex.exec(attrsString))) {
+          props[attrMatch[1]] = attrMatch[2];
+        }
+
+        const attrs = Object.entries(props)
+          .map(([k, v]) => `${k}="${v}"`)
+          .join(' ');
+        newNodes.push({
+          type: 'html',
+          value: `<img ${attrs}>`,
+        });
+
+        lastIndex = match.index + match[0].length;
+      }
+
+      if (newNodes.length) {
+        if (lastIndex < value.length) {
+          newNodes.push({ type: 'text', value: value.slice(lastIndex) });
+        }
+        parent.children.splice(index, 1, ...newNodes);
+        return index + newNodes.length;
+      }
+    });
+  };
+}


### PR DESCRIPTION
## Summary
- implement `remark-image-shortcode` plugin to transform `{{< Image >}}` shortcode
- register plugin in `astro.config.mjs`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68486ceaf480832a85d9df12004706bf